### PR TITLE
Adding smb_sensors meta package

### DIFF
--- a/smb_sensors/CMakeLists.txt
+++ b/smb_sensors/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(smb_sensors)
+find_package(catkin REQUIRED)
+catkin_metapackage()

--- a/smb_sensors/package.xml
+++ b/smb_sensors/package.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>smb_sensors</name>
+  <version>0.0.2</version>
+  <description>Metapackage for SuperMegaBot sensor related packages</description>
+  <maintainer email="thomas.mantel@mavt.ethz.ch">Thomas Mantel</maintainer>
+  <license>TODO</license>
+  <url type="website">http://github.com/ETHZ-RobotX/SuperMegaBot</url>
+  <author email="thomas.mantel@mavt.ethz.ch">Thomas Mantel</author>
+
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <exec_depend>flir_camera_driver</exec_depend> 
+  <exec_depend>versavis</exec_depend>
+  <exec_depend>realsense2_camera</exec_depend>
+  <exec_depend>rslidar_sdk</exec_depend>
+  <export>
+    <metapackage />
+  </export>
+</package>


### PR DESCRIPTION
This PR adds a catkin meta package that simplifies building on the robot.
It depends on 
* versavis
* flir_camera_driver
* realsense2_camera
* rslidar_sdk