### PR TITLE
improve usability of localization launch file

### DIFF
--- a/smb_slam/launch/localization.launch
+++ b/smb_slam/launch/localization.launch
@@ -5,6 +5,7 @@
   <arg name="launch_sensors"      default="false"/>
   <arg name="use_lidar_odometry"  default="false"/>
   <arg name="map_name"            default="Wangen_mapdecimated.pcd" /> 
+  <arg name="pcd_filepath"        default="$(find smb)/data/$(arg map_name)" />
   <arg name="launch_lidar_odometry"   default="false"/>
 
   <include file="$(find smb)/launch/sensors.launch" if="$(arg launch_sensors)">
@@ -14,7 +15,7 @@
   <group if="$(arg use_lidar_odometry)">
     <include file="$(find icp_localization)/launch/icp_node.launch">
       <arg name="launch_rviz" value="$(arg launch_rviz)"/>
-      <arg name="pcd_filepath"  value="$(find smb_slam)/maps/$(arg map_name)"/>
+      <arg name="pcd_filepath"  value="$(arg pcd_filepath)"/>
       <arg name="parameter_filepath"   value="$(find smb_slam)/config/localization/param_with_lidar_odometry.yaml"/>
     </include>
 
@@ -34,7 +35,7 @@
 
     <include file="$(find icp_localization)/launch/icp_node.launch">
       <arg name="launch_rviz" value="$(arg launch_rviz)"/>
-      <arg name="pcd_filepath"  value="$(find smb_slam)/maps/$(arg map_name)"/>
+      <arg name="pcd_filepath"  value="$(arg pcd_filepath)"/>
       <arg name="parameter_filepath"   value="$(find smb_slam)/config/localization/param_with_camera_odometry.yaml"/>
     </include>
 


### PR DESCRIPTION
Give users an easier way of specifying a map file that is not constrained to the smb_slam directory