### PR TITLE
add 'world' arg for selecting different worlds in simulation

### DIFF
--- a/smb_gazebo/launch/sim.launch
+++ b/smb_gazebo/launch/sim.launch
@@ -11,6 +11,7 @@
   <arg name="launch_gazebo_gui"           default="false"/>
   <arg name="mpc"                         default="false"/>
   <arg name="keyboard_teleop"             default="false"/>
+  <arg name="world"                       default="WaA"/>
 
 
   <include file="$(find smb_control)/launch/smb_control.launch">
@@ -24,9 +25,10 @@
   </include>
 
   <include file="$(find smb_gazebo)/launch/smb_gazebo.launch">
-    <arg name="description_name"   value="$(arg description_name)"/>
+    <arg name="description_name"    value="$(arg description_name)"/>
     <arg name="control_namespace"   value="$(arg control_namespace)"/>
-    <arg name="run_gui"           value="$(arg launch_gazebo_gui)"/>
+    <arg name="run_gui"             value="$(arg launch_gazebo_gui)"/>
+    <arg name="world"               value="$(arg world)"/>
   </include>
 
   <include file="$(find smb_opc)/launch/opc.launch" if="$(arg launch_rviz)"/>


### PR DESCRIPTION
For planning tutorial, we mainly use `planner_tutorial.world` in smb_common/smb_gazebo/worlds for simple demonstration. By adding a 'world' arg in sim.launch, we could achieve simulation in different worlds. Example are as follows:

```shell
# planner_tutorial: demo world for path planning tutorial
roslaunch smb_gazebo sim.launch launch_gazebo_gui:=true world:=planner_tutorial
# WaA: default world
roslaunch smb_gazebo sim.launch launch_gazebo_gui:=true world:=WaA
```