### PR TITLE
separate cam and imu

### DIFF
--- a/smb/launch/sensors.launch
+++ b/smb/launch/sensors.launch
@@ -145,7 +145,7 @@
 
         <param name="frame_id" value="blackfly_right_optical_link" />
         <param name="serial" value="$(arg cam0_serial)" />
-        <param name="acquisition_frame_rate" value="5" />
+        <param name="acquisition_frame_rate" value="4" />
         <param name="acquisition_frame_rate_enable" value="true" />
         <param name="image_format_color_coding" value="BayerRG8" />
         <param name="color_processing_algorithm" value="HQ_LINEAR" />

--- a/smb/launch/sensors.launch
+++ b/smb/launch/sensors.launch
@@ -1,10 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <launch>
   
-  <!-- launch versavis: ADIS 16448 IMU and FLIR blackfly rgb cam -->
-  <arg name="launch_versavis"
+  <!-- launch ADIS 16448 IMU related nodes -->
+  <arg name="launch_imu_interface"
        default="true" 
-       doc="Launch the RGB camera and IMU related nodes (triggered through versavis)"/>
+       doc="Launch the IMU related nodes (read out through versavis)"/>
+
+  <!-- launch rgb cam (FLIR blackfly) -->
+  <arg name="launch_rgb_cam"
+       default="false"
+       doc="Launch the RGB camera related nodes"/>
 
   <!-- launch depth cam -->
   <arg name="launch_depth_cam"
@@ -73,13 +78,31 @@
    </include>
   </group>
 
-  <!-- launch versavis: ADIS 16448 IMU and FLIR blackfly rgb cam -->
-  <group if="$(arg launch_versavis)" >
+  <!-- launch imu interface for ADIS 16448 IMU -->
+  <group if="$(arg launch_imu_interface)" >
+    <!-- Run VersaVIS link. -->
+    <node name="rosserial_python" pkg="rosserial_python" type="serial_node.py"
+      args="_port:=/dev/versavis _baud:=250000" respawn="true" output="screen" />
+
+    <!-- Publish IMU messages -->
+    <node name="versavis_imu_receiver" pkg="versavis_adis16448_receiver"
+        type="versavis_imu_receiver" required="true" output="screen">
+      <!-- ADIS16448AMLZ parameters -->
+      <param name="imu_accelerator_sensitivity"           value="0.000833" />
+      <param name="imu_gyro_sensitivity"                  value="0.04" />
+      <param name="imu_acceleration_covariance"           value="0.043864908" /> <!-- no idea where it is from -->
+      <param name="imu_gyro_covariance"                   value="6e-9" /> <!-- no idea where it is from -->
+      <param name="imu_sub_topic"  type="string"          value="/versavis/imu_micro"/>
+    </node>
+  </group>
+
+  <!-- lunch rgb camera (flir camera driver)-->
+  <group if="$(arg launch_rgb_cam)" >
     <!-- camera name prefix -->
-    <arg name="camera_name"             default="BFS" />
+    <arg name="camera_name"             default="rgb_camera" />
     <arg name="camera_type"             default="usb" />
     <!-- camera manager -->
-    <arg name="camera_manager"          value="$(arg camera_name)_camera_manager" />
+    <arg name="camera_manager"          value="camera_nodelet_manager" />
     <arg name="cam0_serial"             value="0" />
     <arg name="node_start_delay_cam0"   value="5.0" />
 
@@ -92,24 +115,22 @@
         <param name="num_worker_threads" value="4" />
     </node>
 
-    <group ns="$(arg camera_name)_$(arg camera_type)_0" >
+    <group ns="$(arg camera_name)" >
       <!-- camera driver nodelet -->
-      <node pkg="nodelet" type="nodelet" name="camera_nodelet"
-            args="load spinnaker_camera_driver/SpinnakerCameraNodelet /$(arg camera_manager)"
-            launch-prefix="bash -c 'sleep $(arg node_start_delay_cam0); $0 $@'" >
+      <node pkg="nodelet" type="nodelet" name="rgb_camera_nodelet"
+            args="load spinnaker_camera_driver/SpinnakerCameraNodelet /$(arg camera_manager)" >
 
         <param name="frame_id" value="blackfly_right_optical_link" />
         <param name="serial" value="$(arg cam0_serial)" />
-        <param name="acquisition_frame_rate_enable" value="false" />
+        <param name="acquisition_frame_rate" value="5" />
+        <param name="acquisition_frame_rate_enable" value="true" />
         <param name="image_format_color_coding" value="BayerRG8" />
         <param name="color_processing_algorithm" value="HQ_LINEAR" />
         <param name="camera_info_url" value="package://smb/config/$(arg smb_name)_cam0.yaml" />
 
         <!-- Trigger related config -->
         <param name="acquisition_mode" value="Continuous" />
-        <param name="trigger_source" value="Line0" /> <!-- Pin 2 -->
-        <param name="enable_trigger" value="On" />
-        <param name="trigger_activation_mode" value="RisingEdge" />
+        <param name="enable_trigger" value="Off" />
 
         <!-- Exposure related config -->
         <param name="exposure_mode" value="Timed" />
@@ -127,39 +148,7 @@
         <param name="auto_gain" value="Continuous" />
         <param name="auto_white_balance" value="Continuous" />
       </node>
-      <node pkg="nodelet" type="nodelet" name="compile_nodelet_cam0"
-            args="load versavis/VersaVISSynchronizerNodelet /$(arg camera_manager)"
-            output="screen"
-            required="true">
-        <param name="driver_topic" type="string" value="/$(arg camera_name)_$(arg camera_type)_0/image_numbered" />
-        <param name="versavis_topic" type="string" value="/versavis/cam0/" />
-        <param name="imu_offset_us" type="int" value="0"/>
-        <param name="publish_slow_images" type="bool" value="true"/>
-        <param name="publish_every_n_image" type="int" value="10"/>
-        <param name="camera_info_topic" type="string" value="camera_info"/>
-      </node>
     </group>
-
-    <!-- Run VersaVIS link. -->
-    <node name="rosserial_python" pkg="rosserial_python" type="serial_node.py"
-      args="_port:=/dev/versavis _baud:=250000" respawn="true" output="screen" />
-
-    <!-- Reset VersaVIS with ros message -->
-    <node pkg="rostopic" type="rostopic" name="resetter"
-      args="pub /versavis/reset std_msgs/Bool false --once" output="screen" />
-
-    <!-- Recieve IMU message. -->
-    <node name="versavis_imu_receiver" pkg="versavis"
-        type="versavis_imu_receiver" required="true" output="screen">
-      <!-- ADIS16448AMLZ parameters -->
-      <param name="imu_accelerator_sensitivity"           value="0.000833" />
-      <!-- <param name="imu_gyro_sensitivity"             value="0.04" /> -->
-      <param name="imu_gyro_sensitivity"                  value="0.04" />
-      <param name="imu_acceleration_covariance"           value="0.043864908" /> <!-- no idea where it is from -->
-      <param name="imu_gyro_covariance"                   value="6e-9" /> <!-- no idea where it is from -->
-      <param name="imu_sub_topic"  type="string"          value="/versavis/imu_micro"/>
-    </node>
-
   </group>
 
 

--- a/smb/launch/sensors.launch
+++ b/smb/launch/sensors.launch
@@ -8,8 +8,8 @@
 
   <!-- launch rgb cam (FLIR blackfly) -->
   <arg name="launch_rgb_cam"
-       default="false"
-       doc="Launch the RGB camera related nodes"/>
+       default="remote"
+       doc="Launch the RGB camera related nodes? Options: local, remote (on Jetson GPU), false (default)"/>
 
   <!-- launch depth cam -->
   <arg name="launch_depth_cam"
@@ -38,6 +38,27 @@
   <arg name="smb_name"
        default="$(env SMB_NAME)"
        doc="Name of the SMB in the format smb26x (relevant for calibrations)" />
+
+  <arg name="GPU_user" 
+       default="$(env USER)"
+       doc="Username to use on the jetson xavier GPU"/>
+
+
+  <!-- evaluate where to start the rgb camera node (based on argument launch_rgb_cam) -->
+  <arg name="rgb_cam_host"
+       value="" unless="$(eval arg('launch_rgb_cam')=='remote')"
+       doc="Host on which to launch rgb camera related nodes (and camera is connected to) - set based on argument launch_rgb_cam" />
+  <arg name="rgb_cam_host"
+       value="jetson" if="$(eval arg('launch_rgb_cam')=='remote')" 
+       doc="Host on which to launch rgb camera related nodes (and camera is connected to) - set based on argument launch_rgb_cam" />
+/>
+
+  <!-- define Jetson host (machine)-->
+  <machine  name="jetson" 
+            address="jetson-xavier" 
+            env-loader="~/jetson_env.sh" 
+            user="$(arg GPU_user)"
+            default="false"/>
 
   <!-- Set global simulation parameter -->
   <param name="/simulation" value="false"/>
@@ -93,22 +114,23 @@
       <param name="imu_acceleration_covariance"           value="0.043864908" /> <!-- no idea where it is from -->
       <param name="imu_gyro_covariance"                   value="6e-9" /> <!-- no idea where it is from -->
       <param name="imu_sub_topic"  type="string"          value="/versavis/imu_micro"/>
+      <param name="imu_pub_topic"  type="string"          value="/imu"/>
     </node>
   </group>
 
-  <!-- lunch rgb camera (flir camera driver)-->
-  <group if="$(arg launch_rgb_cam)" >
+  <!-- launch rgb camera (flir camera driver)-->
+  <group if="$(eval arg('launch_rgb_cam')=='local' or arg('launch_rgb_cam')=='remote')">
     <!-- camera name prefix -->
     <arg name="camera_name"             default="rgb_camera" />
     <arg name="camera_type"             default="usb" />
     <!-- camera manager -->
     <arg name="camera_manager"          value="camera_nodelet_manager" />
     <arg name="cam0_serial"             value="0" />
-    <arg name="node_start_delay_cam0"   value="5.0" />
 
     <!-- camera nodelet system -->
     <!-- nodelet manager -->
     <node pkg="nodelet" type="nodelet" name="$(arg camera_manager)"
+          machine="$(arg rgb_cam_host)"
           args="manager"
           output="screen"
           required="true" >
@@ -117,7 +139,8 @@
 
     <group ns="$(arg camera_name)" >
       <!-- camera driver nodelet -->
-      <node pkg="nodelet" type="nodelet" name="rgb_camera_nodelet"
+      <node pkg="nodelet" type="nodelet" name="rgb_camera_nodelet" 
+            machine="$(arg rgb_cam_host)"
             args="load spinnaker_camera_driver/SpinnakerCameraNodelet /$(arg camera_manager)" >
 
         <param name="frame_id" value="blackfly_right_optical_link" />

--- a/smb/launch/smb.launch
+++ b/smb/launch/smb.launch
@@ -3,33 +3,38 @@
   <!-- General -->
   <arg name="smb_name"
        default="$(env SMB_NAME)"
-       doc="Name of the SMB in the format smb26x (relevant for calibrations)" />
+       doc="Name of the SMB in the format smb26x (relevant for calibrations)." />
 
-  <!-- launch versavis: ADIS 16448 IMU and FLIR blackfly rgb cam -->
-  <arg name="launch_versavis"                       
+  <!-- launch sensors -->
+  <arg name="launch_sensors"
+       default="true"
+       doc="Launch sensors like IMU, rgb camera etc. Overrides all other sensor arguments if set to false."/>
+
+  <!-- launch IMU interface for ADIS 16448 -->
+  <arg name="launch_imu_interface"                       
        default="true" 
-       doc="Launch the RGB camera and IMU related nodes (triggered through versavis)"/>
+       doc="Launch the IMU related nodes."/>
   
-  <!-- launch depth cam -->
-  <arg name="launch_depth_cam" 
-       default="false" 
-       doc="Launch the depth camera related nodes"/>
+  <!-- launch RGB camera -->
+  <arg name="launch_rgb_cam"                       
+       default="remote" 
+       doc="Define whether and where to run the rgb camera nodes. Options: 'remote' (on Jetson Xavier), 'local' or 'false'."/>
 
   <!-- launch tracking cam -->
   <arg name="launch_tracking_cam"
        default="true"
-       doc="Launch the tracking camera related nodes"/>
+       doc="Launch the tracking camera related nodes."/>
+  
+  <!-- launch depth cam -->
+  <arg name="launch_depth_cam" 
+       default="false" 
+       doc="Launch the depth camera related nodes."/>
 
   <!-- use lidar odometry -->
   <arg name="use_lidar_odometry"
        default="false"
        doc="Use lidar odometry instead of the tracking camera odometry if set to true."/>
   
-  <!-- launch sensors -->
-  <arg name="launch_sensors"
-       default="true"
-       doc="Launch depth camera, versavis and tracking camera."/>
-
   <!-- enable ekf -->
   <arg name="enable_ekf" 
        default="false"
@@ -67,7 +72,7 @@
   <!-- keyboard_teleop -->
   <arg name="keyboard_teleop"
         default="false"
-        doc="Launch node to send control commands (twist msgs) using the keyboard"/>
+        doc="Launch node to send control commands (twist msgs) using the keyboard."/>
 
   <!-- Set global simulation parameter -->
   <param name="/simulation" value="false"/>
@@ -76,7 +81,8 @@
   <group if="$(arg launch_sensors)">
     <include file="$(find smb)/launch/sensors.launch">
       <arg name="smb_name"                 value="$(arg smb_name)"/>
-      <arg name="launch_versavis"          value="$(arg launch_versavis)"/>
+      <arg name="launch_imu_interface"     value="$(arg launch_imu_interface)"/>
+      <arg name="launch_rgb_cam"           value="$(arg launch_rgb_cam)"/>
       <arg name="launch_depth_cam"         value="$(arg launch_depth_cam)"/>
       <arg name="launch_tracking_cam"      value="$(arg launch_tracking_cam)"/>
     </include>

--- a/smb_sensors/package.xml
+++ b/smb_sensors/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>smb_sensors</name>
-  <version>0.0.2</version>
+  <version>1.0.0</version>
   <description>Metapackage for SuperMegaBot sensor related packages</description>
   <maintainer email="thomas.mantel@mavt.ethz.ch">Thomas Mantel</maintainer>
   <license>TODO</license>
@@ -12,7 +12,7 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <exec_depend>flir_camera_driver</exec_depend> 
-  <exec_depend>versavis</exec_depend>
+  <exec_depend>versavis_adis16448_receiver</exec_depend>
   <exec_depend>realsense2_camera</exec_depend>
   <exec_depend>rslidar_sdk</exec_depend>
   <exec_depend>smb_powerstatus</exec_depend>

--- a/smb_sensors/package.xml
+++ b/smb_sensors/package.xml
@@ -11,7 +11,6 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <exec_depend>flir_camera_driver</exec_depend> 
   <exec_depend>versavis_adis16448_receiver</exec_depend>
   <exec_depend>realsense2_camera</exec_depend>
   <exec_depend>rslidar_sdk</exec_depend>


### PR DESCRIPTION
This PR separates the acquisition of RGB camera and IMU data

- The main IMU (ADIS16448) is read out via the [versavis](https://github.com/ethz-asl/versavis_hw) using a newly created package called [smb_imu_interface](https://github.com/ETHZ-RobotX/smb_imu_interface). 
- The RGB is now connected directly to the GPU and triggered by software (not via versavis hw). 

An adapted smb_hw.repos file is pushed to smb_dev (https://github.com/ETHZ-RobotX/smb_dev/pull/56)

