### PR TITLE
Add missing O3D dependency

### DIFF
--- a/smb_slam/package.xml
+++ b/smb_slam/package.xml
@@ -15,6 +15,7 @@
 	<depend>libpointmatcher</depend>
 	<depend>roslib</depend>
 	<depend>icp_localization</depend>
+	<depend>open3d_slam_ros</depend>
 	
 	<build_depend>libgoogle-glog-dev</build_depend>
 


### PR DESCRIPTION
Otherwise we need to build `open3d_slam_ros` manually.