### PR TITLE
fix missing model config gazebo

### DIFF
--- a/smb_gazebo/launch/smb_gazebo.launch
+++ b/smb_gazebo/launch/smb_gazebo.launch
@@ -2,7 +2,7 @@
 <launch>
 
   <!-- Model path -->
-  <arg name="model_path"                            default="$(find smb_gazebo)/"/>
+  <arg name="model_path"                            default="$(find smb_gazebo)/models/"/>
   <arg name="robot_model_name"                      default="smb"/>
 
   <!-- Name of the world -->


### PR DESCRIPTION
Fixed the following bug when using `roslaunch smb_gazebo sim.launch launch_gazebo_gui:=true`

![Screenshot from 2024-04-26 15-36-14](https://github.com/ETHZ-RobotX/smb_common/assets/33963319/07aaa33f-f966-4336-890d-03b63499175d)
