### PR TITLE
make default state of use_sim_time to false instead of hard setting it

### DIFF
--- a/smb_msf_graph/launch/smb_msf_graph.launch
+++ b/smb_msf_graph/launch/smb_msf_graph.launch
@@ -2,7 +2,7 @@
 <launch>
 
     <!-- Parameters -->
-    <arg name="use_sim_time"                value="false" />
+    <arg name="use_sim_time"                default="false" />
     <arg name="launch_o3d_slam"             default="true" />
     <arg name="lidar_odometry_topic_name"   default="/mapping_node/scan2map_odometry"/>
     

--- a/smb_slam/launch/localization.launch
+++ b/smb_slam/launch/localization.launch
@@ -2,6 +2,7 @@
 <launch>
 
   <!-- Arguments -->
+  <arg name="use_sim_time"          default="false" />
   <arg name="cloud_topic"           default="/rslidar/points"  doc="input topic for the lidar pointcloud"/>
   <arg name="parameter_filename"    default="param_rs16_localization.lua" doc="param file name"/>
   <arg name="parameter_folder_path" default="$(find smb_slam)/config/open3d_slam/" doc="directory for the parameter files"/>
@@ -21,6 +22,7 @@
     <arg name="launch_rviz"           value="$(arg launch_rviz)"/>
     <arg name="pcd_file_path"         value="$(arg pcd_file_path)"/>
     <arg name="map_saving_folder"     value="$(arg map_saving_folder)"/>
+    <arg name="use_sim_time"          value="$(arg use_sim_time)" />
   </include>
   
 </launch>


### PR DESCRIPTION
### OPTION 2: RUNNING WITH ONLINE SLAM + MSF GRAPH
`roslaunch smb_gazebo sim.launch launch_gazebo_gui:=true world:=planner_tutorial`

### launch the state estimator with online slam
`roslaunch smb_msf_graph smb_msf_graph.launch use_sim_time:=true`

### launch the autonomous navigation
`roslaunch smb_navigation navigate2d_ompl.launch sim:=true global_frame:=world_graph_msf odom_topic:=/graph_msf/est_odometry_odom_imu`